### PR TITLE
call api reformatting

### DIFF
--- a/src/components/CatsBreeds.js
+++ b/src/components/CatsBreeds.js
@@ -14,27 +14,30 @@ function CatsBreeds() {
   useEffect(() => {
     axios
       .get("https://api.thecatapi.com/v1/breeds")
-      .then((response) => setBreeds(response.data))
+      .then((response) => {
+        setBreeds(response.data);
+        console.log("Razas cargadas:", response.data);
+      })
       .catch((error) => console.log(error));
   }, []);
 
-  useEffect(() => {
-    if (selectedBreed) {
-      axios
-        .get(
-          `https://api.thecatapi.com/v1/images/search?limit=100&breed_id=${
-            breeds.find((breed) => breed.name === selectedBreed).id
-          }`
-        )
-        .then((response) => setBreedImages(response.data))
-        .catch((error) => console.log(error));
-    } else {
-      setBreedImages([]);
-    }
-  }, [selectedBreed, breeds]);
-
   const handleChange = (event) => {
     setSelectedBreed(event.target.value);
+    console.log("raza seleccionada:", event.target.value);
+
+    const selectedBreedId = breeds.find(
+      (breed) => breed.name === event.target.value
+    )?.id;
+    console.log("selectedBreedId:", selectedBreedId);
+    axios
+      .get(
+        `https://api.thecatapi.com/v1/images/search?limit=100&breed_id=${selectedBreedId}`
+      )
+      .then((response) => {
+        setBreedImages(response.data);
+        console.log("imagenes de razas cargadas:", response.data);
+      })
+      .catch((error) => console.log(error));
   };
 
   return (

--- a/src/components/DogsBreeds.js
+++ b/src/components/DogsBreeds.js
@@ -21,29 +21,23 @@ function Breeds() {
       .catch((error) => console.log(error));
   }, []);
 
-  useEffect(() => {
-    if (selectedBreed) {
-      const selectedBreedId = breeds.find(
-        (breed) => breed.name === selectedBreed
-      )?.id;
-      console.log("selectedBreedId:", selectedBreedId);
-      axios
-        .get(
-          `https://api.thedogapi.com/v1/images/search?limit=100&breed_id=${selectedBreedId}`
-        )
-        .then((response) => {
-          setBreedImages(response.data);
-          console.log("imagenes de razas cargadas:", response.data);
-        })
-        .catch((error) => console.log(error));
-    } else {
-      setBreedImages([]);
-    }
-  }, [selectedBreed, breeds]);
-
   const handleChange = (event) => {
     setSelectedBreed(event.target.value);
     console.log("raza seleccionada:", event.target.value);
+
+    const selectedBreedId = breeds.find(
+      (breed) => breed.name === event.target.value
+    )?.id;
+    console.log("selectedBreedId:", selectedBreedId);
+    axios
+      .get(
+        `https://api.thedogapi.com/v1/images/search?limit=100&breed_id=${selectedBreedId}`
+      )
+      .then((response) => {
+        setBreedImages(response.data);
+        console.log("imagenes de razas cargadas:", response.data);
+      })
+      .catch((error) => console.log(error));
   };
 
   return (


### PR DESCRIPTION
se reformateó el código donde se realizaba la api call para obtener imágenes desde la misma, eliminando el 2do useEffect que lo efectuaba, y trasladando esa petición al evento onChange.